### PR TITLE
Add basic support for arrays in parameter types

### DIFF
--- a/swagger-dsl/src/main/kotlin/dev/moetz/swagger/builder/model/Parameter.kt
+++ b/swagger-dsl/src/main/kotlin/dev/moetz/swagger/builder/model/Parameter.kt
@@ -13,6 +13,8 @@ sealed class Parameter {
     private var schema: Schema? = null
     protected open var type: String? = null
     private var enum: List<String>? = null
+    private var format: String? = null
+    private var arraySchema: Schema? = null
 
     @SwaggerDsl
     fun description(description: String) {
@@ -51,6 +53,27 @@ sealed class Parameter {
     }
 
 
+    /**
+     * Set the format and item type of array parameter.
+     * **See Also:** [Documentation](https://swagger.io/docs/specification/2-0/describing-parameters/#array)
+     *
+     * @param format The format of the parameter.
+     * @param arraySchema The [Schema] of the items in this array
+     */
+    @SwaggerDsl
+    fun array(format: String, arraySchema: Schema) {
+        this.format = format
+        this.arraySchema = arraySchema
+        val allowedTypes = listOf("csv", "ssv", "tsv", "pipes", "multi")
+        if (allowedTypes.contains(format).not()) {
+            throw IllegalArgumentException("Format ${format} not allowed. Must be one of the allowed values: ${allowedTypes.joinToString()}")
+        }
+        if(format == "multi" && (this !is QueryParameter || this !is FormDataParameter)) {
+            throw IllegalArgumentException("Type ${format} only allowed on query or form data parameters")
+        }
+    }
+
+
     val definition: SwaggerDefinition.Path.ParameterDefinition
         get() = SwaggerDefinition.Path.ParameterDefinition(
             name = name,
@@ -59,7 +82,9 @@ sealed class Parameter {
             required = required,
             type = type,
             enum = enum,
-            schema = schema?.definition
+            schema = schema?.definition,
+            format = format,
+            arraySchema = arraySchema?.definition
         )
 
 }

--- a/swagger-dsl/src/main/kotlin/dev/moetz/swagger/definition/SwaggerDefinition.kt
+++ b/swagger-dsl/src/main/kotlin/dev/moetz/swagger/definition/SwaggerDefinition.kt
@@ -1,5 +1,7 @@
 package dev.moetz.swagger.definition
 
+import dev.moetz.swagger.builder.model.ArraySchema
+
 
 data class SwaggerDefinition(
     val swaggerFileVersion: String,
@@ -43,7 +45,9 @@ data class SwaggerDefinition(
             val required: Boolean?,
             val type: String?,
             val enum: List<String>?,
-            val schema: SchemaDefinition?
+            val schema: SchemaDefinition?,
+            val format: String?,
+            val arraySchema: SchemaDefinition?
         )
 
         data class ResponseDefinition(

--- a/swagger-dsl/src/main/kotlin/dev/moetz/swagger/generator/YamlFileGenerator.kt
+++ b/swagger-dsl/src/main/kotlin/dev/moetz/swagger/generator/YamlFileGenerator.kt
@@ -202,6 +202,14 @@ object YamlFileGenerator {
             )
         }
 
+        format?.also {
+            list.add("${PADDING}collectionFormat: $format")
+            list.addAll(
+                arraySchema!!.toYamlLines()
+                    .map { "${PADDING}$it" }
+            )
+        }
+
         return list.toList()
     }
 

--- a/swagger-dsl/src/test/kotlin/dev/moetz/swagger/generator/YamlFileGeneratorTest.kt
+++ b/swagger-dsl/src/test/kotlin/dev/moetz/swagger/generator/YamlFileGeneratorTest.kt
@@ -455,6 +455,75 @@ definitions:
     }
 
     @Test
+    fun testArrayType() {
+        val definition = SwaggerBuilder.generate {
+            info {
+                title("Test API")
+                version("1.2.3")
+                description("Some API description")
+                host("swagger.example.org")
+                basePath("/swaggertest/")
+                schemes("https")
+            }
+
+            tag("someTag", "Some information about the tag")
+
+            path("/somePath", "get") {
+                operationId("somePath")
+                tags("someTag")
+
+                queryParameter("test") {
+                    description("array query parameter")
+                    array("csv", createArraySchema {
+                        items(createTypeSchema("string") {
+                            description("type of array")
+                        })
+                    })
+                }
+
+                response(200) {
+                    description("success")
+                }
+            }
+        }
+
+        val generatedYaml = YamlFileGenerator.generate(definition)
+
+        generatedYaml.trimMargin() shouldBeEqualTo """
+swagger: '2.0'
+info:
+  description: "Some API description"
+  version: '1.2.3'
+  title: "Test API"
+host: "swagger.example.org"
+basePath: "/swaggertest/"
+schemes:
+  - https
+tags:
+  - name: someTag
+    description: "Some information about the tag"
+paths:
+  "/somePath":
+    get:
+      tags:
+        - someTag
+      operationId: "somePath"
+      parameters:
+        - name: test
+          in: query
+          description: "array query parameter"
+          collectionFormat: csv
+          type: array
+          items:
+            type: string
+            description: "type of array"
+      responses:
+        200:
+          description: "success"
+ """.trimMargin()
+    }
+
+    @Test
     fun simpleYamlDefinitionTest() {
         val definition = SwaggerBuilder.generate {
             info {


### PR DESCRIPTION
Provides a basic implementation of https://swagger.io/docs/specification/2-0/describing-parameters/#array 
Does not include min/max/unique